### PR TITLE
.NET and NuGet upgrades

### DIFF
--- a/MigrateDetailedMessages/MigrateDetailedMessages.csproj
+++ b/MigrateDetailedMessages/MigrateDetailedMessages.csproj
@@ -10,8 +10,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MigrateDetailedMessages/Program.cs
+++ b/MigrateDetailedMessages/Program.cs
@@ -13,16 +13,11 @@ await Host.CreateDefaultBuilder(args)
     .Build()
     .RunAsync();
 
-class Worker
+class Worker(IConfiguration config)
     : BackgroundService
 {
-    private readonly string _connectionString;
-    private readonly string _workerPath;
-    public Worker(IConfiguration config)
-    {
-        _connectionString = config.GetConnectionString("Sched");
-        _workerPath = config["WorkerPath"];
-    }
+    private readonly string _connectionString = config.GetConnectionString("Sched")!;
+    private readonly string _workerPath = config["WorkerPath"]!;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -47,16 +42,12 @@ class Worker
     {
         using MemoryStream inputStream = new(Encoding.UTF8.GetBytes(contents));
         using FileStream fileStream = messageGZipFile.OpenWrite();
-        GZip.Compress(inputStream, fileStream);
+        Compress(inputStream, fileStream);
     }
-}
 
-public static class GZip
-{
-    private const int BUFFER_SIZE = 0x4000;
-
-    public static void Compress(Stream inputStream, Stream outputStream)
+    private static void Compress(Stream inputStream, Stream outputStream)
     {
+        const int BUFFER_SIZE = 0x4000;
         byte[] buffer = new byte[BUFFER_SIZE];
         using GZipStream gzip = new(outputStream, CompressionMode.Compress);
         int count;

--- a/Publish-Scheduler.ps1
+++ b/Publish-Scheduler.ps1
@@ -1,6 +1,7 @@
 $PublishDir = "C:\Scheduler_Publish"
+# The API now references and bundles the BlazorWasm project, so it does not
+# need to be published separately.
 $DotNetProjects = "SimpleSchedulerAPI", "SimpleSchedulerService", "SimpleSchedulerServiceChecker"
-$WasmProject = "SimpleSchedulerBlazorWasm"
 
 $FrameworkDependentDir = Join-Path -Path $PublishDir -ChildPath "framework-dependent"
 $SelfContainedDir = Join-Path -Path $PublishDir -ChildPath "win-x64-self-contained"
@@ -27,10 +28,3 @@ foreach ($Project in $DotNetProjects) {
 	$DestDir = Join-Path -Path $SelfContainedDir -ChildPath $Project
 	Move-Item -Path ".\$($Project)\bin\Release\net10.0\win-x64\publish" -Destination $DestDir
 }
-
-# Build the WASM project (not a .NET project) and copy to both locations
-dotnet publish ".\$($WasmProject)" --configuration Release
-$DestDir = Join-Path -Path $FrameworkDependentDir -ChildPath $WasmProject
-Copy-Item -Path ".\$($WasmProject)\bin\Release\net10.0\publish" -Destination $DestDir -Recurse
-$DestDir = Join-Path -Path $SelfContainedDir -ChildPath $WasmProject
-Move-Item -Path ".\$($WasmProject)\bin\Release\net10.0\publish" -Destination $DestDir

--- a/Publish-Scheduler.ps1
+++ b/Publish-Scheduler.ps1
@@ -14,23 +14,23 @@ New-Item -ItemType Directory -Path $PublishDir
 New-Item -ItemType Directory -Path $FrameworkDependentDir
 New-Item -ItemType Directory -Path $SelfContainedDir
 
-# Build each project and publish assuming the target machine has .NET 6.0 installed
+# Build each project and publish assuming the target machine has .NET 10.0 installed
 foreach ($Project in $DotNetProjects) {
 	dotnet publish ".\$($Project)" --configuration Release
 	$DestDir = Join-Path -Path $FrameworkDependentDir -ChildPath $Project
-	Move-Item -Path ".\$($Project)\bin\Release\net6.0\publish" -Destination $DestDir
+	Move-Item -Path ".\$($Project)\bin\Release\net10.0\publish" -Destination $DestDir
 }
 
 # Build each project and publish self-contained for Windows x64
 foreach ($Project in $DotNetProjects) {
 	dotnet publish ".\$($Project)" --configuration Release --self-contained --runtime win-x64
 	$DestDir = Join-Path -Path $SelfContainedDir -ChildPath $Project
-	Move-Item -Path ".\$($Project)\bin\Release\net6.0\win-x64\publish" -Destination $DestDir
+	Move-Item -Path ".\$($Project)\bin\Release\net10.0\win-x64\publish" -Destination $DestDir
 }
 
 # Build the WASM project (not a .NET project) and copy to both locations
 dotnet publish ".\$($WasmProject)" --configuration Release
 $DestDir = Join-Path -Path $FrameworkDependentDir -ChildPath $WasmProject
-Copy-Item -Path ".\$($WasmProject)\bin\Release\net6.0\publish" -Destination $DestDir -Recurse
+Copy-Item -Path ".\$($WasmProject)\bin\Release\net10.0\publish" -Destination $DestDir -Recurse
 $DestDir = Join-Path -Path $SelfContainedDir -ChildPath $WasmProject
-Move-Item -Path ".\$($WasmProject)\bin\Release\net6.0\publish" -Destination $DestDir
+Move-Item -Path ".\$($WasmProject)\bin\Release\net10.0\publish" -Destination $DestDir

--- a/SimpleSchedulerAPI/Program.cs
+++ b/SimpleSchedulerAPI/Program.cs
@@ -6,7 +6,7 @@ using Polly;
 using Polly.Retry;
 using SimpleSchedulerEmail;
 using SimpleSchedulerData;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using SimpleSchedulerSerilogEmail;
 using Serilog;
 using SimpleSchedulerAPI;
@@ -34,7 +34,7 @@ builder.Services.AddSingleton<IScheduleManager, ScheduleManager>();
 builder.Services.AddSingleton<IUserManager, UserManager>();
 builder.Services.AddSingleton<IWorkerManager, WorkerManager>();
 
-builder.Services.AddSingleton<SqlDatabase>(sp =>
+builder.Services.AddSingleton(sp =>
 {
     string connectionString = sp.GetRequiredService<IConfiguration>().GetConnectionString("SimpleScheduler")!;
     AsyncRetryPolicy retryPolicy = sp.GetRequiredService<AsyncRetryPolicy>();
@@ -111,7 +111,7 @@ WebApplication app = builder.Build();
 
 app.UsePathBase(app.Configuration["PathBase"]);
 
-app.UseMiddleware(typeof(ExceptionHandlingMiddleware));
+app.UseMiddleware<ExceptionHandlingMiddleware>();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/SimpleSchedulerAPI/Program.cs
+++ b/SimpleSchedulerAPI/Program.cs
@@ -130,8 +130,10 @@ if (app.Environment.IsDevelopment())
 }
 else
 {
-    app.UseExceptionHandler("/Error");
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+    // ExceptionHandlingMiddleware (above) handles all unhandled exceptions globally.
+    // Don't add UseExceptionHandler("/Error") here — the path has no endpoint, so the
+    // re-execution lands on MapFallbackToFile("index.html"), which only allows GET/HEAD,
+    // and a thrown exception on a POST then surfaces as 405 Method Not Allowed.
     app.UseHsts();
 }
 

--- a/SimpleSchedulerAPI/Program.cs
+++ b/SimpleSchedulerAPI/Program.cs
@@ -15,7 +15,13 @@ using SimpleSchedulerAPI.ApiServices;
 
 Serilog.Debugging.SelfLog.Enable(msg => System.Diagnostics.Debug.WriteLine(msg));
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+WebApplicationBuilder builder = WebApplication.CreateBuilder(new WebApplicationOptions
+{
+    Args = args,
+    ContentRootPath = AppContext.BaseDirectory
+});
+
+builder.Host.UseWindowsService();
 
 builder.Services.AddHttpContextAccessor();
 

--- a/SimpleSchedulerAPI/SimpleSchedulerAPI.csproj
+++ b/SimpleSchedulerAPI/SimpleSchedulerAPI.csproj
@@ -12,16 +12,16 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
-		<PackageReference Include="Serilog" Version="4.3.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+		<PackageReference Include="Serilog" Version="4.3.1" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.4" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.7" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SimpleSchedulerAPI/SimpleSchedulerAPI.csproj
+++ b/SimpleSchedulerAPI/SimpleSchedulerAPI.csproj
@@ -20,6 +20,7 @@
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.7" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
 	</ItemGroup>
@@ -27,6 +28,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\SimpleSchedulerApiModels\SimpleSchedulerApiModels.csproj" />
 		<ProjectReference Include="..\SimpleSchedulerAppServices\SimpleSchedulerAppServices.csproj" />
+		<ProjectReference Include="..\SimpleSchedulerBlazorWasm\SimpleSchedulerBlazorWasm.csproj" />
 		<ProjectReference Include="..\SimpleSchedulerSerilogEmail\SimpleSchedulerSerilogEmail.csproj" />
 	</ItemGroup>
 

--- a/SimpleSchedulerAPI/appsettings.json
+++ b/SimpleSchedulerAPI/appsettings.json
@@ -1,6 +1,8 @@
 {
   "AllowedHosts": "*",
 
+  "Urls": "http://localhost:5266",
+
   "ConnectionStrings": {
     "SimpleScheduler": "Server=(localdb)\\MSSqlLocalDb;Database=SimpleSchedulerSqlServerDB;Integrated Security=True;"
   },

--- a/SimpleSchedulerAppServices/ModelBuilders.cs
+++ b/SimpleSchedulerAppServices/ModelBuilders.cs
@@ -112,7 +112,7 @@ internal static class ModelBuilders
         }
 
         return TimeSpan.FromSeconds(durationInSeconds.Value).Humanize(precision: 1,
-            maxUnit: Humanizer.Localisation.TimeUnit.Minute,
-            minUnit: Humanizer.Localisation.TimeUnit.Second);
+            maxUnit: TimeUnit.Minute,
+            minUnit: TimeUnit.Second);
     }
 }

--- a/SimpleSchedulerAppServices/SimpleSchedulerAppServices.csproj
+++ b/SimpleSchedulerAppServices/SimpleSchedulerAppServices.csproj
@@ -10,8 +10,8 @@
 		<AssemblyVersion>7.0.0</AssemblyVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Humanizer" Version="2.14.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+		<PackageReference Include="Humanizer" Version="3.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\SimpleSchedulerDataEntities\SimpleSchedulerDataEntities.csproj" />

--- a/SimpleSchedulerBlazorWasm/SimpleSchedulerBlazorWasm.csproj
+++ b/SimpleSchedulerBlazorWasm/SimpleSchedulerBlazorWasm.csproj
@@ -13,11 +13,11 @@
 	<ItemGroup>
 		<PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
 		<PackageReference Include="Blazored.Typeahead" Version="4.7.0" />
-		<PackageReference Include="Blazorise.Bootstrap5" Version="1.8.2" />
-		<PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.8.2" />
+		<PackageReference Include="Blazorise.Bootstrap5" Version="2.1.2" />
+		<PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.1.2" />
 		<PackageReference Include="CurrieTechnologies.Razor.SweetAlert2" Version="5.6.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SimpleSchedulerData/SimpleSchedulerData.csproj
+++ b/SimpleSchedulerData/SimpleSchedulerData.csproj
@@ -10,9 +10,9 @@
 		<AssemblyVersion>7.0.0</AssemblyVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Dapper" Version="2.1.66" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
-		<PackageReference Include="Polly" Version="8.6.3" />
+		<PackageReference Include="Dapper" Version="2.1.72" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+		<PackageReference Include="Polly" Version="8.6.6" />
 	</ItemGroup>
 </Project>

--- a/SimpleSchedulerEmail/Emailer.cs
+++ b/SimpleSchedulerEmail/Emailer.cs
@@ -62,7 +62,7 @@ public record class Emailer(
                 break;
         }
 
-        if (!string.IsNullOrWhiteSpace(UserName))
+        if (!string.IsNullOrWhiteSpace(UserName) && !string.IsNullOrWhiteSpace(Password))
         {
             await emailClient.AuthenticateAsync(UserName, Password).ConfigureAwait(false);
         }
@@ -106,7 +106,7 @@ public record class Emailer(
                 break;
         }
 
-        if (!string.IsNullOrWhiteSpace(UserName))
+        if (!string.IsNullOrWhiteSpace(UserName) && !string.IsNullOrWhiteSpace(Password))
         {
             emailClient.Authenticate(UserName, Password);
         }

--- a/SimpleSchedulerEmail/SimpleSchedulerEmail.csproj
+++ b/SimpleSchedulerEmail/SimpleSchedulerEmail.csproj
@@ -10,9 +10,9 @@
 		<AssemblyVersion>7.0.0</AssemblyVersion>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="MailKit" Version="4.13.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+		<PackageReference Include="MailKit" Version="4.16.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
 	</ItemGroup>
 </Project>

--- a/SimpleSchedulerFakeData/SimpleSchedulerFakeData.csproj
+++ b/SimpleSchedulerFakeData/SimpleSchedulerFakeData.csproj
@@ -16,10 +16,10 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Bogus" Version="35.6.3" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+		<PackageReference Include="Bogus" Version="35.6.5" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
 	</ItemGroup>
 
 </Project>

--- a/SimpleSchedulerService/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/SimpleSchedulerService/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net6.0\publish\win-x64\</PublishDir>
+    <PublishDir>bin\Release\net10.0\publish\win-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>

--- a/SimpleSchedulerService/SimpleSchedulerService.csproj
+++ b/SimpleSchedulerService/SimpleSchedulerService.csproj
@@ -12,13 +12,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-		<PackageReference Include="Serilog" Version="4.3.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+		<PackageReference Include="Serilog" Version="4.3.1" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 		<PackageReference Include="RunProcessAsTask" Version="1.2.4" />
 	</ItemGroup>

--- a/SimpleSchedulerServiceChecker/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/SimpleSchedulerServiceChecker/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net6.0\publish\win-x64\</PublishDir>
+    <PublishDir>bin\Release\net10.0\publish\win-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>

--- a/SimpleSchedulerServiceChecker/SimpleSchedulerServiceChecker.csproj
+++ b/SimpleSchedulerServiceChecker/SimpleSchedulerServiceChecker.csproj
@@ -12,13 +12,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-		<PackageReference Include="Serilog" Version="4.3.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+		<PackageReference Include="Serilog" Version="4.3.1" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
 	</ItemGroup>
 

--- a/SimpleSchedulerServiceClient/SimpleSchedulerServiceClient.csproj
+++ b/SimpleSchedulerServiceClient/SimpleSchedulerServiceClient.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
 	</ItemGroup>
 
 </Project>

--- a/SimpleSchedulerTests/SimpleSchedulerTests.csproj
+++ b/SimpleSchedulerTests/SimpleSchedulerTests.csproj
@@ -12,13 +12,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
+		<PackageReference Include="coverlet.collector" Version="10.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/readme.md
+++ b/readme.md
@@ -1,34 +1,96 @@
 To build from command line (specifically PowerShell on Windows):
 
-## API:
+## API (also hosts the Blazor WASM frontend):
 
 `dotnet publish .\SimpleSchedulerAPI\ --configuration Release`
 
-This will put your output into ./bin/Release/net9.0/publish/
+This will put your output into `.\SimpleSchedulerAPI\bin\Release\net10.0\publish\`.
 
-Add this to IIS, and ensure its application pool is running under a user that has rights to the database (if you're using Windows Authentication for SQL Server), and rights to the filesystem for the workers directory.
+The API project references `SimpleSchedulerBlazorWasm`, so the WASM static files
+are copied into `wwwroot/` automatically and served by the same process.
+
+### Running as a Windows Service
+
+The API is configured to run either as a console app (during development) or as
+a Windows Service (in production) — `Host.UseWindowsService()` detects which.
+
+1. Publish the project (see above) and copy the publish folder to your server,
+   for example `C:\Services\SimpleSchedulerAPI`.
+2. Set the listen URL in `appsettings.json` (`"Urls": "http://+:5266"` to bind
+   on all interfaces, or pick whatever host/port you want). Configure
+   connection strings, JWT settings, etc. in the same file.
+3. Open an **elevated** PowerShell prompt and run:
+
+   ```powershell
+   New-Service -Name SimpleSchedulerAPI `
+       -BinaryPathName "C:\Services\SimpleSchedulerAPI\SimpleSchedulerAPI.exe" `
+       -DisplayName "Simple Scheduler API" `
+       -Description "Simple Scheduler API and Blazor WASM frontend" `
+       -StartupType Automatic
+   # Optional: run under a specific account so it has rights to SQL / the
+   # workers folder. Add: -Credential (Get-Credential MyDomain\MyUser)
+
+   Start-Service SimpleSchedulerAPI
+   ```
+
+   Or with `sc.exe`:
+
+   ```powershell
+   sc.exe create SimpleSchedulerAPI binPath= "C:\Services\SimpleSchedulerAPI\SimpleSchedulerAPI.exe" start= auto DisplayName= "Simple Scheduler API"
+   sc.exe description SimpleSchedulerAPI "Simple Scheduler API and Blazor WASM frontend"
+   sc.exe start SimpleSchedulerAPI
+   ```
+
+4. To uninstall:
+
+   ```powershell
+   Stop-Service SimpleSchedulerAPI
+   Remove-Service SimpleSchedulerAPI   # or: sc.exe delete SimpleSchedulerAPI
+   ```
+
+The service account needs:
+- Permission to bind the configured URL (`http://+:port` requires either
+  admin rights or a `netsh http add urlacl` reservation).
+- Read/write access to the workers folder and any log paths in
+  `appsettings.json`.
+- SQL access (Windows auth uses the service account; otherwise put the
+  credentials in the connection string).
+
+If you want HTTPS, configure a `Kestrel:Endpoints:Https` block in
+`appsettings.json` with a certificate, or put a reverse proxy (IIS, nginx,
+YARP) in front of the service. By default the app listens on plain HTTP only;
+the `UseHttpsRedirection` middleware is a no-op until an HTTPS endpoint exists.
 
 -- TODO: Add instructions for running this in Mac or Linux
 
-## Blazor WASM:
+## Blazor WASM (standalone hosting — optional):
+
+The WASM frontend ships inside the API service by default, so no separate
+hosting is required. If you would rather host the static files on their own
+(CDN, static site, separate web server), publish the project directly:
 
 `dotnet publish .\SimpleSchedulerBlazorWasm\ --configuration Release`
 
-This will put your output into ./bin/Release/net9.0/publish/
-
-This is a static WASM application, so you should be able to host this on any web server that you'd like, including a static site.
+This puts the static output in
+`.\SimpleSchedulerBlazorWasm\bin\Release\net10.0\publish\wwwroot\`. Point that
+deployment at your API by editing `wwwroot/appsettings.json` (`ApiUrl`).
 
 ## Service:
 
 `dotnet publish .\SimpleSchedulerService\ --configuration Release`
 
-This will put your output into ./bin/Release/net9.0/publish/
+This will put your output into `.\SimpleSchedulerService\bin\Release\net10.0\publish\`.
 
-Copy the output to your server, and execute the following as administrator (This is for Windows):
+Copy the output to your server and install as a Windows Service:
 
-`sc.exe create MyServiceName binpath="X:\path-to-app\SimpleSchedulerService.exe"`
-
--- TODO: Provide the PowerShell equivalent
+```powershell
+New-Service -Name SimpleScheduler `
+    -BinaryPathName "C:\Services\SimpleSchedulerService\SimpleSchedulerService.exe" `
+    -DisplayName "Simple Scheduler" `
+    -Description "Simple Scheduler job runner" `
+    -StartupType Automatic
+Start-Service SimpleScheduler
+```
 
 -- TODO: Add instructions for running this in Mac or Linux
 
@@ -36,13 +98,18 @@ Copy the output to your server, and execute the following as administrator (This
 
 `dotnet publish .\SimpleSchedulerServiceChecker\ --configuration Release`
 
-This will put your output into ./bin/Release/net9.0/publish/
+This will put your output into `.\SimpleSchedulerServiceChecker\bin\Release\net10.0\publish\`.
 
-Copy the output to your server, and execute the following as administrator (This is for Windows):
+Install as a Windows Service the same way:
 
-`sc.exe create MyServiceName binpath="X:\path-to-app\SimpleSchedulerServiceChecker.exe"`
-
--- TODO: Provide the PowerShell equivalent
+```powershell
+New-Service -Name SimpleSchedulerChecker `
+    -BinaryPathName "C:\Services\SimpleSchedulerServiceChecker\SimpleSchedulerServiceChecker.exe" `
+    -DisplayName "Simple Scheduler Checker" `
+    -Description "Simple Scheduler health checker" `
+    -StartupType Automatic
+Start-Service SimpleSchedulerChecker
+```
 
 -- TODO: Add instructions for running this in Mac or Linux
 


### PR DESCRIPTION
Code Review — dotnet-10 branch (1 commit ahead of main)

  Overview

  Upgrades the solution from .NET 6 → .NET 10 (combined with the prior commit on-branch) and refreshes NuGet dependencies. Includes a few minor refactors using newer C# syntax and one small functional change
  in Emailer.

  What changed

  - Framework: net6.0 → net10.0 across all .csproj and publish profiles; PS publish script paths updated.
  - NuGet: patch/minor bumps for MS extensions, Serilog, Dapper, Polly, MailKit, Bogus. Major bumps for Humanizer (2→3), Blazorise.* (1→2), MSTest (3→4), Microsoft.Data.SqlClient (6→7),
  Swashbuckle.AspNetCore.* (9→10), coverlet.collector (6→10), Microsoft.NET.Test.Sdk (17→18).
  - MigrateDetailedMessages/Program.cs — converted Worker to a primary constructor; folded the previously public GZip static class into a private static Worker.Compress method.
  - SimpleSchedulerAPI/Program.cs — Microsoft.OpenApi.Models → Microsoft.OpenApi; UseMiddleware(typeof(...)) → generic UseMiddleware<T>(); dropped redundant generic on AddSingleton.
  - SimpleSchedulerAppServices/ModelBuilders.cs — Humanizer.Localisation.TimeUnit.X → TimeUnit.X.
  - SimpleSchedulerEmail/Emailer.cs — small functional change: only authenticate when both UserName and Password are non-blank.

  Quality / style

  - Refactors are idiomatic for modern C# (primary ctor, generic middleware, type-inferred AddSingleton). Nothing to push back on.
  - Folding GZip into Worker is sensible — it was only ever called from one place.
  - Diff is well-scoped; no incidental churn.

  Issues / risks

  - Emailer.cs:65, 109 — silent behavior change. Previously, configuring UserName without Password would attempt SMTP AUTH (and fail loudly); now it silently skips authentication and may send unauthenticated.
  If a misconfigured environment ever set username-only, mail will start going through anonymously instead of erroring. Consider either logging a warning when only one of the two is set, or treating a missing
  Password while UserName is present as a configuration error rather than silently skipping. No test was added to lock in the new behavior.
  - MigrateDetailedMessages/Program.cs:19-20 — null-forgiving on config reads. config.GetConnectionString("Sched")! and config["WorkerPath"]! will defer a missing-config crash to a NullReferenceException deep
  in ExecuteAsync. For a one-shot migration tool that's tolerable, but a ?? throw new InvalidOperationException("...") at construction would fail fast with a useful message. Low priority.
  - Major-version bumps need a manual smoke test. Verify before merging:
    - Blazorise 1.8 → 2.1 is a significant release with breaking API changes — exercise the Blazor WASM UI (forms, modals, datagrids, validation) in a browser, not just dotnet build.
    - Humanizer 2 → 3 — ModelBuilders.GetFriendlyDuration should be spot-checked against representative durations; TimeUnit reachable via using Humanizer; alone implies the namespace re-export still works in
  3.x, but worth confirming it builds with TreatWarningsAsErrors=true.
    - Swashbuckle 9 → 10 / Microsoft.OpenApi — open /swagger in Development and confirm the spec renders.
    - Microsoft.Data.SqlClient 6 → 7 — 7.x changed the default for Encrypt / has stricter TLS behavior in some configurations; verify connection strings still work in your envs.
    - MSTest 3 → 4 — run the full test project; some attribute behaviors changed.
  - No test changes despite the Emailer behavior tweak and the framework jump. At minimum the existing test suite needs to be run; the diff doesn't tell us it passed.

  Security

  - Nothing introduced. Emailer change tightens AUTH preconditions (slightly safer in that auth never sends a null password), at the cost of the silent-fallback concern above.

  Performance

  - No hot-path changes. Primary-ctor refactor and Compress inlining are zero-impact.

  Recommendation

  Approvable as a maintenance/upgrade PR once you've (a) run the test suite, (b) manually exercised the Blazor UI under Blazorise 2.x, and (c) decided whether the Emailer username-without-password case should
  warn/throw rather than silently skip auth.

# Install as Windows Service

## Summary of changes

  - SimpleSchedulerAPI/SimpleSchedulerAPI.csproj — added Microsoft.Extensions.Hosting.WindowsServices package and a ProjectReference to SimpleSchedulerBlazorWasm. The WASM project's wwwroot output is now
  bundled into the API publish.
  - SimpleSchedulerAPI/Program.cs — set ContentRootPath = AppContext.BaseDirectory in WebApplicationOptions (so the service doesn't resolve files from C:\Windows\System32) and called
  builder.Host.UseWindowsService(). Detects service-vs-console automatically, so F5 in dev still works.
  - SimpleSchedulerAPI/appsettings.json — added "Urls": "http://localhost:5266" so the service binds a fixed port (override per-host).
  - Publish-Scheduler.ps1 — removed the standalone WASM publish step (now bundled with the API).
  - README.md — replaced IIS instructions with New-Service/sc.exe install commands for the API, scheduler service, and checker; documented URL binding, service-account permissions, and HTTPS options.

  Notes on operating the service:
  - http://+:port bindings need either admin or a one-time netsh http add urlacl url=http://+:5266/ user="DOMAIN\svc-account" reservation.
  - The existing app.UseHttpsRedirection() is harmless on HTTP-only deployments — it logs a warning and skips redirecting when no HTTPS endpoint/port is configured.
  - Microsoft.AspNetCore.Components.WebAssembly.Server was already a dependency, so UseBlazorFrameworkFiles() + MapFallbackToFile("index.html") in Program.cs correctly serve the bundled WASM with no further
  code changes.