### PR TITLE
Fix worker dropdown filter on jobs page (#54)

### DIFF
--- a/SimpleSchedulerBlazorWasm/Pages/Jobs.razor.cs
+++ b/SimpleSchedulerBlazorWasm/Pages/Jobs.razor.cs
@@ -14,15 +14,7 @@ partial class Jobs
 {
 	private EditContext SearchEditContext { get; set; } = default!;
 
-	private readonly SearchModel _searchCriteria = new();
-	private SearchModel SearchCriteria
-	{
-		get
-		{
-			_searchCriteria.WorkerID = WorkerID;
-			return _searchCriteria;
-		}
-	}
+	private SearchModel SearchCriteria { get; } = new();
 
 	private Worker[] AllWorkers { get; set; } = Array.Empty<Worker>();
 
@@ -43,6 +35,7 @@ partial class Jobs
 
 	protected override async Task OnInitializedAsync()
 	{
+		SearchCriteria.WorkerID = WorkerID;
 		SearchEditContext = new(SearchCriteria);
 		SearchEditContext.OnFieldChanged += async (sender, e) =>
 		{


### PR DESCRIPTION
## Summary
- Fixes #54 — selecting a worker from the dropdown now correctly filters the jobs grid.
- The `SearchCriteria` getter in `Jobs.razor.cs` had a side effect that reset `WorkerID` from the route parameter on every property access, clobbering the dropdown selection before `LoadJobsAsync` could read it.
- Initialize `SearchCriteria.WorkerID` once from the route parameter in `OnInitializedAsync` and removed the side-effect from the getter.

## Test plan
- [ ] Navigate to the jobs page and verify it loads all jobs.
- [ ] Select a worker from the dropdown — the grid should refresh and show only jobs for that worker (plus any ERR jobs added by the secondary fetch).
- [ ] Change the status dropdown — the grid should refresh with the combined filter applied.
- [ ] Navigate directly to `/jobs/{WorkerID}` — the dropdown should be pre-selected and the grid filtered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)