### PR TITLE
Remove Blazorise dependency (#56)

### DIFF
--- a/SimpleSchedulerBlazorWasm/Components/Workers/WorkerDisplay.razor
+++ b/SimpleSchedulerBlazorWasm/Components/Workers/WorkerDisplay.razor
@@ -34,46 +34,46 @@
                 @* TODO: Figure out margin with CSS rather than inline *@
                 @if (Worker.Worker.IsActive)
                 {
-                    <Button Color="Color.Warning" Size="Size.Small" @onclick="EditWorker" Style="margin-right: 20px;">
+                    <button type="button" class="btn btn-warning btn-sm" @onclick="EditWorker" style="margin-right: 20px;">
                         <i class="bi bi-pencil"></i>
                         Edit
-                    </Button>
+                    </button>
                 }
                 @if (Worker.Worker.IsActive)
                 {
                     if (AllWorkers.Any(w => w.ParentWorkerID == Worker.Worker.ID))
                     {
-                        <Button Color="Color.Secondary" Size="Size.Small" Outline title="This worker has children. Unable to delete." Style="margin-right: 20px;">
+                        <button type="button" class="btn btn-outline-secondary btn-sm" title="This worker has children. Unable to delete." style="margin-right: 20px;">
                             <i class="bi bi-trash"></i>
                             Delete
-                        </Button>
+                        </button>
                     }
                     else
                     {
-                        <Button Color="Color.Danger" Size="Size.Small" @onclick="DeleteWorker" Style="margin-right: 20px;">
+                        <button type="button" class="btn btn-danger btn-sm" @onclick="DeleteWorker" style="margin-right: 20px;">
                             <i class="bi bi-trash"></i>
                             Delete
-                        </Button>
+                        </button>
                     }
                 }
                 else
                 {
-                    <Button Color="Color.Primary" Size="Size.Small" @onclick="ReactivateWorker" Style="margin-right: 20px;">
+                    <button type="button" class="btn btn-primary btn-sm" @onclick="ReactivateWorker" style="margin-right: 20px;">
                         <i class="bi bi-box-arrow-up-left"></i>
                         Reactivate
-                    </Button>
+                    </button>
                 }
                 @if (Worker.Worker.IsActive)
                 {
-                    <Button Color="Color.Success" Size="Size.Small" @onclick="RunWorker" Style="margin-right: 20px;">
+                    <button type="button" class="btn btn-success btn-sm" @onclick="RunWorker" style="margin-right: 20px;">
                         <i class="bi bi-play"></i>
                         Run
-                    </Button>
+                    </button>
                 }
-                <Button Color="Color.Success" Size="Size.Small" Outline @onclick="GoToJobs">
+                <button type="button" class="btn btn-outline-success btn-sm" @onclick="GoToJobs">
                     <i class="bi bi-person-workspace"></i>
                     Jobs
-                </Button>
+                </button>
             </div>
         </div>
     }

--- a/SimpleSchedulerBlazorWasm/Program.cs
+++ b/SimpleSchedulerBlazorWasm/Program.cs
@@ -1,7 +1,4 @@
 using Blazored.LocalStorage;
-using Blazorise;
-using Blazorise.Bootstrap5;
-using Blazorise.Icons.FontAwesome;
 using CurrieTechnologies.Razor.SweetAlert2;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -16,11 +13,6 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddBlazoredLocalStorage();
 
 builder.Services.AddSweetAlert2(options => options.Theme = SweetAlertTheme.Bootstrap4);
-
-builder.Services
-	.AddBlazorise(options => options.Immediate = true)
-	.AddBootstrap5Providers()
-	.AddFontAwesomeIcons();
 
 builder.Services.AddScoped<ITokenLookup, TokenLookup>();
 

--- a/SimpleSchedulerBlazorWasm/SimpleSchedulerBlazorWasm.csproj
+++ b/SimpleSchedulerBlazorWasm/SimpleSchedulerBlazorWasm.csproj
@@ -13,8 +13,6 @@
 	<ItemGroup>
 		<PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
 		<PackageReference Include="Blazored.Typeahead" Version="4.7.0" />
-		<PackageReference Include="Blazorise.Bootstrap5" Version="2.1.2" />
-		<PackageReference Include="Blazorise.Icons.FontAwesome" Version="2.1.2" />
 		<PackageReference Include="CurrieTechnologies.Razor.SweetAlert2" Version="5.6.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.7" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.7" PrivateAssets="all" />

--- a/SimpleSchedulerBlazorWasm/_Imports.razor
+++ b/SimpleSchedulerBlazorWasm/_Imports.razor
@@ -11,4 +11,3 @@
 @using SimpleSchedulerBlazorWasm.Components
 @using SimpleSchedulerApiModels
 @using CurrieTechnologies.Razor.SweetAlert2
-@using Blazorise

--- a/SimpleSchedulerBlazorWasm/wwwroot/index.html
+++ b/SimpleSchedulerBlazorWasm/wwwroot/index.html
@@ -21,8 +21,6 @@
     <link href="manifest.json" rel="manifest" />
     <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />
     <link rel="apple-touch-icon" sizes="192x192" href="icon-192.png" />
-    <link href="_content/Blazorise/blazorise.css" rel="stylesheet" />
-    <link href="_content/Blazorise.Bootstrap5/blazorise.bootstrap5.css" rel="stylesheet" />
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
Closes #56.

Blazorise's licensing changed and the project needed a replacement. After auditing usage, Blazorise was only being used for **six `<Button>` elements in a single file** (`WorkerDisplay.razor`). The rest of the UI already renders Bootstrap 5 markup directly (`<div class="card">`, `<div class="form-group">`, etc.). Rather than swapping in another component library and taking on a new dependency, this PR drops Blazorise entirely and replaces the affected buttons with native Bootstrap 5 button markup.

The `Color`/`Size`/`Outline` props map 1:1 to the classes Blazorise.Bootstrap5 already emits, so the rendered output is visually equivalent:

| Blazorise | Bootstrap 5 |
| --- | --- |
| `Color="Color.Warning"` | `btn btn-warning` |
| `Color="Color.Danger"` | `btn btn-danger` |
| `Color="Color.Primary"` | `btn btn-primary` |
| `Color="Color.Success"` | `btn btn-success` |
| `Color="Color.Secondary" Outline` | `btn btn-outline-secondary` |
| `Color="Color.Success" Outline` | `btn btn-outline-success` |
| `Size="Size.Small"` | `btn-sm` |

### Changes
- `WorkerDisplay.razor`: replaced six Blazorise `<Button>` elements with native `<button class="btn ...">`.
- `Program.cs`: removed `using Blazorise*` and the `.AddBlazorise().AddBootstrap5Providers().AddFontAwesomeIcons()` registration.
- `_Imports.razor`: removed `@using Blazorise`.
- `SimpleSchedulerBlazorWasm.csproj`: removed `Blazorise.Bootstrap5` and `Blazorise.Icons.FontAwesome` package references.
- `index.html`: removed the two `_content/Blazorise/*.css` `<link>` tags.

FontAwesome CSS is still bundled via the SCSS pipeline (not Blazorise), so any icons relying on it are unaffected.

## Test plan
- [x] `dotnet build` — succeeds with 0 warnings / 0 errors.
- [x] `dotnet run` — dev server starts and serves `/` with HTTP 200; no Blazorise references remain in the served HTML.
- [ ] Manually visit the Workers page and verify the Edit / Delete / Reactivate / Run / Jobs buttons render with the same colors, sizing, and spacing as before.
- [ ] Click each button to confirm `@onclick` handlers still fire (Edit, Delete, Reactivate, Run, Jobs navigation).
- [ ] Verify the disabled-looking "Delete" button (when a worker has children) still shows the outline-secondary style and the tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)