### PR TITLE
Add auto-submit login URL via email query string (#39)

### DIFF
--- a/SimpleSchedulerBlazorWasm/Pages/Login.razor.cs
+++ b/SimpleSchedulerBlazorWasm/Pages/Login.razor.cs
@@ -19,8 +19,13 @@ partial class Login
 
     private bool Loading { get; set; }
     private bool SubmittedSuccessfully { get; set; }
+    private bool _autoSubmitted;
 
     private string[] AllEmails { get; set; } = Array.Empty<string>();
+
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "email")]
+    public string? Email { get; set; }
 
     private class LoginModel
     {
@@ -35,14 +40,19 @@ partial class Login
             "Login/GetAllUserEmails",
             new());
 
-        if (error is not null || reply?.EmailAddresses.Any() != true)
+        if (error is null && reply?.EmailAddresses.Any() == true)
         {
-            return;
+            AllEmails = reply.EmailAddresses;
         }
 
-        AllEmails = reply.EmailAddresses;
-
         await base.OnParametersSetAsync();
+
+        if (!_autoSubmitted && !string.IsNullOrWhiteSpace(Email))
+        {
+            _autoSubmitted = true;
+            Model.Email = Email;
+            await HandleValidSubmit();
+        }
     }
 
     private async Task HandleValidSubmit()


### PR DESCRIPTION
## Summary
Closes #39.

Visiting `/login?email=foo@example.com` now auto-submits the login request, so you can bookmark this URL for a one-click "send me the magic link" flow.

### Implementation
- Added an `Email` parameter to `Login.razor.cs` bound from the `email` query-string parameter via `[SupplyParameterFromQuery(Name = "email")]`.
- In `OnParametersSetAsync`, after loading the existing email list, if `Email` is non-empty and we haven't auto-submitted yet, sets `Model.Email` and invokes the existing `HandleValidSubmit()`. The `_autoSubmitted` flag prevents a re-fire on subsequent parameter changes.
- Restructured the early-return in `OnParametersSetAsync` so the auto-submit path still runs even when `GetAllUserEmails` errors or returns an empty list.

### URL shape: query string vs path
The issue described the URL as `/login/joe@whatever.com`. I prototyped that first by adding `@page "/login/{Email}"`, but the Blazor WASM dev server returns **404** for URLs whose last segment looks like a file extension (e.g. `.com`, `.org`, `.net`) because its static-file middleware treats them as file requests. Routes like `/login/foo` work, but the realistic case `/login/joe@example.com` does not. Switching to the query string (`/login?email=...`) sidesteps this and works in both dev and production.

## Test plan
- [x] `dotnet build` — succeeds with 0 warnings / 0 errors.
- [x] Dev server returns HTTP 200 for `/login?email=joe@example.com`.
- [ ] Manually open `/login?email=<your-email>` in a browser and confirm the SubmitEmail request fires automatically and the "check your email" toast appears.
- [ ] Refresh the page mid-flow and confirm it doesn't double-submit (the `_autoSubmitted` guard).
- [ ] Open `/login` (no query) and confirm the existing manual login form still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)