### PR TITLE
Add filter-by-worker button on job rows (#33)

### DIFF
--- a/SimpleSchedulerBlazorWasm/Components/Jobs/JobRow.razor
+++ b/SimpleSchedulerBlazorWasm/Components/Jobs/JobRow.razor
@@ -14,6 +14,10 @@
                 <i class="bi bi-building"></i>
                 Worker
             </button>
+            <button class="btn btn-xs btn-outline-info" @onclick="FilterByThisWorker" title="Filter jobs by this worker">
+                <i class="bi bi-funnel"></i>
+                Filter
+            </button>
         </div>
     </div>
     <div class="queue-date-container" title="Inserted @Job.InsertDateUTC.FormatDate() @Job.InsertDateUTC.FormatTime()">

--- a/SimpleSchedulerBlazorWasm/Components/Jobs/JobRow.razor.cs
+++ b/SimpleSchedulerBlazorWasm/Components/Jobs/JobRow.razor.cs
@@ -185,4 +185,9 @@ partial class JobRow
         Nav.NavigateTo($"workers/filter/{Worker.ID}");
         return Task.CompletedTask;
     }
+
+    private async Task FilterByThisWorker()
+    {
+        await JobsComponent.FilterByWorkerAsync(Worker.ID);
+    }
 }

--- a/SimpleSchedulerBlazorWasm/Pages/Jobs.razor.cs
+++ b/SimpleSchedulerBlazorWasm/Pages/Jobs.razor.cs
@@ -102,6 +102,14 @@ partial class Jobs
 		SetLoadingOff();
 	}
 
+	public async Task FilterByWorkerAsync(long workerId)
+	{
+		SearchCriteria.WorkerID = workerId;
+		SetLoadingOn();
+		await LoadJobsAsync();
+		SetLoadingOff();
+	}
+
 	private async Task LoadJobsAsync()
 	{
 		(Error? error, GetJobsReply? reply) = await ServiceClient.PostAsync<GetJobsRequest, GetJobsReply>(


### PR DESCRIPTION
## Summary
Closes #33.

Adds a **Filter** button next to the existing **Worker** button on each row of the Jobs grid. Clicking it sets the worker filter and reloads the grid in place — no more two-hop navigation (Worker → Workers page → Jobs button).

### Implementation
- `Jobs.razor.cs`: new public `FilterByWorkerAsync(long workerId)` method that sets `SearchCriteria.WorkerID`, toggles the loading indicator, and re-runs `LoadJobsAsync()`. Mirrors the existing `RefreshJobs` pattern.
- `JobRow.razor.cs`: new `FilterByThisWorker()` handler that delegates to the parent `JobsComponent` (already passed in as an `[EditorRequired]` parameter).
- `JobRow.razor`: new `<button class="btn btn-xs btn-outline-info">` with a `bi-funnel` icon and a tooltip, placed alongside the existing Worker button.

### Notes
- The URL is not updated when filtering (the route param stays as-is). The dropdown in the search bar still reflects the active filter because it `@bind`s to `SearchCriteria.WorkerID`. If we want to keep the URL in sync as well, that can be a follow-up.

## Test plan
- [x] `dotnet build` — succeeds with 0 warnings / 0 errors.
- [x] Dev server returns HTTP 200 for `/`.
- [ ] Open the Jobs page, click Filter on a row, confirm the grid reloads showing only that worker's jobs and the Worker dropdown reflects the selection.
- [ ] Click Filter on a different worker's row, confirm the grid updates accordingly.
- [ ] Manually clear the worker dropdown back to empty and confirm all jobs reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)