### PR TITLE
Replace plain selects with Bootstrap dropdowns (#27)

### DIFF
--- a/SimpleSchedulerBlazorWasm/Components/BootstrapDropdown.razor
+++ b/SimpleSchedulerBlazorWasm/Components/BootstrapDropdown.razor
@@ -1,0 +1,33 @@
+@typeparam TValue
+
+<div class="dropdown @Class">
+    <button class="btn btn-outline-secondary dropdown-toggle text-start w-100"
+            type="button"
+            id="@Id"
+            data-bs-toggle="dropdown"
+            aria-expanded="false">
+        @(SelectedLabel ?? Placeholder)
+    </button>
+    <ul class="dropdown-menu" aria-labelledby="@Id">
+        @if (IncludeEmpty)
+        {
+            <li>
+                <button type="button"
+                        class="dropdown-item @(IsSelected(default) ? "active" : null)"
+                        @onclick="() => SelectAsync(default)">
+                    @EmptyLabel
+                </button>
+            </li>
+        }
+        @foreach (BootstrapDropdownItem<TValue> item in Items)
+        {
+            <li>
+                <button type="button"
+                        class="dropdown-item @(IsSelected(item.Value) ? "active" : null)"
+                        @onclick="() => SelectAsync(item.Value)">
+                    @item.Label
+                </button>
+            </li>
+        }
+    </ul>
+</div>

--- a/SimpleSchedulerBlazorWasm/Components/BootstrapDropdown.razor.cs
+++ b/SimpleSchedulerBlazorWasm/Components/BootstrapDropdown.razor.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Components;
+
+namespace SimpleSchedulerBlazorWasm.Components;
+
+public partial class BootstrapDropdown<TValue>
+{
+    [Parameter] public TValue? Value { get; set; }
+    [Parameter] public EventCallback<TValue?> ValueChanged { get; set; }
+    [Parameter] public IEnumerable<BootstrapDropdownItem<TValue>> Items { get; set; } = Array.Empty<BootstrapDropdownItem<TValue>>();
+    [Parameter] public string Placeholder { get; set; } = "Select...";
+    [Parameter] public string EmptyLabel { get; set; } = "(none)";
+    [Parameter] public bool IncludeEmpty { get; set; } = true;
+    [Parameter] public string? Class { get; set; }
+    [Parameter] public string? Id { get; set; }
+
+    private string? SelectedLabel
+    {
+        get
+        {
+            if (Value is null)
+            {
+                return null;
+            }
+            foreach (BootstrapDropdownItem<TValue> item in Items)
+            {
+                if (IsSelected(item.Value))
+                {
+                    return item.Label;
+                }
+            }
+            return null;
+        }
+    }
+
+    private bool IsSelected(TValue? candidate) =>
+        EqualityComparer<TValue>.Default.Equals(candidate!, Value!);
+
+    private async Task SelectAsync(TValue? value)
+    {
+        if (IsSelected(value))
+        {
+            return;
+        }
+        Value = value;
+        await ValueChanged.InvokeAsync(value);
+    }
+}
+
+public record BootstrapDropdownItem<TValue>(TValue? Value, string Label);

--- a/SimpleSchedulerBlazorWasm/Pages/Jobs.razor
+++ b/SimpleSchedulerBlazorWasm/Pages/Jobs.razor
@@ -9,35 +9,33 @@
 else
 {
     <div class="container" style="margin-top: 25px;">
-        <EditForm EditContext="SearchEditContext" class="d-flex">
+        <div class="d-flex">
             <div class="form-group">
                 <label for="AllWorkersDropdown">Worker</label>
-                <InputSelect @bind-Value="SearchCriteria.WorkerID" class="form-select" id="AllWorkersDropdown">
-                    <option></option>
-                    @foreach (Worker worker in AllWorkers)
-                    {
-                    <option value="@worker.ID">@worker.WorkerName</option>
-                    }
-            </InputSelect>
+                <BootstrapDropdown TValue="long?"
+                                   Id="AllWorkersDropdown"
+                                   Value="SearchCriteria.WorkerID"
+                                   ValueChanged="OnWorkerFilterChangedAsync"
+                                   Items="WorkerDropdownItems"
+                                   Placeholder="(all workers)"
+                                   EmptyLabel="(all workers)" />
+            </div>
+            <div class="form-group">
+                <label for="StatusDropdown">Status</label>
+                <BootstrapDropdown TValue="string"
+                                   Id="StatusDropdown"
+                                   Value="SearchCriteria.StatusCode"
+                                   ValueChanged="OnStatusFilterChangedAsync"
+                                   Items="StatusDropdownItems"
+                                   Placeholder="(all statuses)"
+                                   EmptyLabel="(all statuses)" />
+            </div>
+            <div class="form-group">
+                <label>&nbsp;</label>
+                <button class="btn btn-primary form-control" @onclick="RefreshJobs">Refresh</button>
+            </div>
         </div>
-        <div class="form-group">
-            <label for="StatusDropdown">Status</label>
-            <InputSelect @bind-Value="SearchCriteria.StatusCode" class="form-select" id="StatusDropdown">
-                <option></option>
-                <option value="NEW">NEW</option>
-                <option value="RUN">RUN</option>
-                <option value="SUC">SUC</option>
-                <option value="ERR">ERR</option>
-                <option value="ACK">ACK</option>
-                <option value="CAN">CAN</option>
-            </InputSelect>
-        </div>
-        <div class="form-group">
-            <label>&nbsp;</label>
-            <button class="btn btn-primary form-control" @onclick="RefreshJobs">Refresh</button>
-        </div>
-    </EditForm>
-</div>
+    </div>
 
     <div id="jobs-container">
         <div class="full-size-header job-container d-flex">

--- a/SimpleSchedulerBlazorWasm/Pages/Jobs.razor.cs
+++ b/SimpleSchedulerBlazorWasm/Pages/Jobs.razor.cs
@@ -1,18 +1,29 @@
 ﻿using CurrieTechnologies.Razor.SweetAlert2;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
 using SimpleSchedulerApiModels;
 using SimpleSchedulerApiModels.Reply.Jobs;
 using SimpleSchedulerApiModels.Reply.Workers;
 using SimpleSchedulerApiModels.Request.Jobs;
 using SimpleSchedulerApiModels.Request.Workers;
+using SimpleSchedulerBlazorWasm.Components;
 using SimpleSchedulerServiceClient;
 
 namespace SimpleSchedulerBlazorWasm.Pages;
 
 partial class Jobs
 {
-	private EditContext SearchEditContext { get; set; } = default!;
+	private static readonly BootstrapDropdownItem<string>[] StatusDropdownItems = new[]
+	{
+		new BootstrapDropdownItem<string>("NEW", "NEW"),
+		new BootstrapDropdownItem<string>("RUN", "RUN"),
+		new BootstrapDropdownItem<string>("SUC", "SUC"),
+		new BootstrapDropdownItem<string>("ERR", "ERR"),
+		new BootstrapDropdownItem<string>("ACK", "ACK"),
+		new BootstrapDropdownItem<string>("CAN", "CAN"),
+	};
+
+	private IEnumerable<BootstrapDropdownItem<long?>> WorkerDropdownItems =>
+		AllWorkers.Select(w => new BootstrapDropdownItem<long?>(w.ID, w.WorkerName));
 
 	private SearchModel SearchCriteria { get; } = new();
 
@@ -33,17 +44,26 @@ partial class Jobs
 
 	private readonly Dictionary<long, Worker> _allWorkersByID = new();
 
-	protected override async Task OnInitializedAsync()
+	protected override Task OnInitializedAsync()
 	{
 		SearchCriteria.WorkerID = WorkerID;
-		SearchEditContext = new(SearchCriteria);
-		SearchEditContext.OnFieldChanged += async (sender, e) =>
-		{
-			SetLoadingOn();
-			await LoadJobsAsync();
-			SetLoadingOff();
-		};
-		await Task.CompletedTask;
+		return Task.CompletedTask;
+	}
+
+	private async Task OnWorkerFilterChangedAsync(long? workerId)
+	{
+		SearchCriteria.WorkerID = workerId;
+		SetLoadingOn();
+		await LoadJobsAsync();
+		SetLoadingOff();
+	}
+
+	private async Task OnStatusFilterChangedAsync(string? statusCode)
+	{
+		SearchCriteria.StatusCode = statusCode;
+		SetLoadingOn();
+		await LoadJobsAsync();
+		SetLoadingOff();
 	}
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/SimpleSchedulerBlazorWasm/Pages/Login.razor
+++ b/SimpleSchedulerBlazorWasm/Pages/Login.razor
@@ -20,13 +20,12 @@
                     <div class="input-group mb-3">
                         @if (AllEmails.Any())
                         {
-                            <InputSelect id="email-address" @bind-Value="Model.Email" class="form-select">
-                                <option></option>
-                                @foreach (string emailAddress in AllEmails)
-                                {
-                                    <option value="@emailAddress">@emailAddress</option>
-                                }
-                            </InputSelect>
+                            <BootstrapDropdown TValue="string"
+                                               Id="email-address"
+                                               @bind-Value="Model.Email"
+                                               Items="EmailDropdownItems"
+                                               Placeholder="Select email address"
+                                               EmptyLabel="(none)" />
                         }
                         else
                         {

--- a/SimpleSchedulerBlazorWasm/Pages/Login.razor.cs
+++ b/SimpleSchedulerBlazorWasm/Pages/Login.razor.cs
@@ -3,6 +3,7 @@ using CurrieTechnologies.Razor.SweetAlert2;
 using Microsoft.AspNetCore.Components;
 using SimpleSchedulerApiModels.Reply.Login;
 using SimpleSchedulerApiModels.Request.Login;
+using SimpleSchedulerBlazorWasm.Components;
 using SimpleSchedulerServiceClient;
 
 namespace SimpleSchedulerBlazorWasm.Pages;
@@ -22,6 +23,9 @@ partial class Login
     private bool _autoSubmitted;
 
     private string[] AllEmails { get; set; } = Array.Empty<string>();
+
+    private IEnumerable<BootstrapDropdownItem<string>> EmailDropdownItems =>
+        AllEmails.Select(e => new BootstrapDropdownItem<string>(e, e));
 
     [Parameter]
     [SupplyParameterFromQuery(Name = "email")]

--- a/SimpleSchedulerBlazorWasm/Pages/WorkerEdit.razor
+++ b/SimpleSchedulerBlazorWasm/Pages/WorkerEdit.razor
@@ -24,17 +24,11 @@
                 </div>
                 <div class="form-group">
                     <label>Parent Worker (this worker will run after the parent is successful)</label>
-                    <InputSelect TValue="long?" class="form-select" @bind-Value="Worker.ParentWorkerID">
-                        <option></option>
-                        @foreach (WorkerIDName w in AllWorkers.OrderBy(w => w.WorkerName))
-                        {
-                            if (w.ID == Worker.ID)
-                            {
-                                continue;
-                            }
-                            <option value="@w.ID">@w.WorkerName</option>
-                        }
-                    </InputSelect>
+                    <BootstrapDropdown TValue="long?"
+                                       @bind-Value="Worker.ParentWorkerID"
+                                       Items="ParentWorkerDropdownItems"
+                                       Placeholder="(no parent)"
+                                       EmptyLabel="(no parent)" />
                 </div>
                 <div class="form-group">
                     <label>Timeout (Minutes)</label>

--- a/SimpleSchedulerBlazorWasm/Pages/WorkerEdit.razor.cs
+++ b/SimpleSchedulerBlazorWasm/Pages/WorkerEdit.razor.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components;
 using SimpleSchedulerApiModels;
 using SimpleSchedulerApiModels.Reply.Workers;
 using SimpleSchedulerApiModels.Request.Workers;
+using SimpleSchedulerBlazorWasm.Components;
 using SimpleSchedulerServiceClient;
 
 namespace SimpleSchedulerBlazorWasm.Pages;
@@ -25,6 +26,12 @@ partial class WorkerEdit
     private bool Loading { get; set; } = true;
     private Worker Worker { get; set; } = new();
     private WorkerIDName[] AllWorkers { get; set; } = default!;
+
+    private IEnumerable<BootstrapDropdownItem<long?>> ParentWorkerDropdownItems =>
+        AllWorkers
+            .Where(w => w.ID != Worker.ID)
+            .OrderBy(w => w.WorkerName)
+            .Select(w => new BootstrapDropdownItem<long?>(w.ID, w.WorkerName));
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
## Summary
Closes #27.

Introduces a reusable `BootstrapDropdown<TValue>` component (under `Components/`) that renders a Bootstrap 5 `dropdown-toggle` + `dropdown-menu` and supports two-way binding via `Value` / `ValueChanged` so existing `@bind-Value` usages keep working. Replaces every plain `<InputSelect>` in the app with the new component.

### What changed
- **New component** `BootstrapDropdown<TValue>` + `BootstrapDropdownItem<TValue>` record. Parameters: `Value`, `ValueChanged`, `Items`, `Placeholder`, `EmptyLabel`, `IncludeEmpty`, `Class`, `Id`. Uses Bootstrap's built-in JS (already loaded via `bootstrap.bundle.min.js`) for open/close — no custom JS interop.
- **Jobs.razor**: worker filter + status filter now use `BootstrapDropdown`. The previous `EditForm` / `EditContext` / `OnFieldChanged` plumbing existed solely to detect dropdown changes for auto-refresh — replaced with explicit `ValueChanged` handlers (`OnWorkerFilterChangedAsync`, `OnStatusFilterChangedAsync`) that call `LoadJobsAsync` directly. The Refresh button keeps working as before.
- **Login.razor**: the email-address dropdown (shown only when the server returns at least one known email) is now a `BootstrapDropdown`. Validation for the underlying `Model.Email` still runs at submit time via `DataAnnotationsValidator` since the attributes are evaluated against the whole model.
- **WorkerEdit.razor**: the parent-worker dropdown is now a `BootstrapDropdown`. Filtering out the current worker (so it can't be its own parent) is done in the `ParentWorkerDropdownItems` getter.

### Behavior notes
- The Bootstrap dropdown is purely click-driven (Bootstrap JS positions and toggles it). Native `<select>` arrow-key/typeahead behavior does not carry over; this is consistent with what the issue asked for ("fancier" dropdowns rather than native ones).
- Existing change-triggered side effects continue to fire: the Jobs grid still reloads when a filter changes, the worker filter dropdown still updates when the row-level Filter button (#33) is clicked, the Login model still gets the selected email, etc.

## Test plan
- [x] `dotnet build` — succeeds with 0 warnings / 0 errors.
- [x] Dev server returns HTTP 200 for `/`, `/login`, and `/workers/1`.
- [ ] Jobs page: open Worker dropdown, pick a worker, confirm the grid reloads filtered. Open Status dropdown, pick a status, confirm the grid reloads with the combined filter. Pick `(all workers)` / `(all statuses)` to clear and confirm reload.
- [ ] Jobs page: click the row-level Filter button (from #33) and confirm the Worker dropdown shows the selected worker's name.
- [ ] Login page: when `GetAllUserEmails` returns addresses, the dropdown lists them; selecting one and clicking Submit fires the existing magic-link flow. When no addresses come back, the plain `<InputText>` fallback still renders.
- [ ] WorkerEdit page: open the Parent Worker dropdown, confirm the current worker is excluded, pick a parent, hit Save, and confirm the update persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)