### PR TITLE
Persist row state to parent so acknowledged jobs do not revert (#30)

### DIFF
--- a/SimpleSchedulerBlazorWasm/Components/Jobs/JobRow.razor.cs
+++ b/SimpleSchedulerBlazorWasm/Components/Jobs/JobRow.razor.cs
@@ -110,6 +110,7 @@ partial class JobRow
         }
 
         Job = reply!.Job;
+        JobsComponent.ReplaceJob(Job);
         Loading = false;
         StateHasChanged();
     }

--- a/SimpleSchedulerBlazorWasm/Pages/Jobs.razor.cs
+++ b/SimpleSchedulerBlazorWasm/Pages/Jobs.razor.cs
@@ -130,6 +130,29 @@ partial class Jobs
 		SetLoadingOff();
 	}
 
+	public void ReplaceJob(Job updatedJob)
+	{
+		for (int i = 0; i < JobDetails.Length; i++)
+		{
+			if (JobDetails[i].ID == updatedJob.ID)
+			{
+				JobDetails[i] = JobDetails[i] with
+				{
+					ScheduleID = updatedJob.ScheduleID,
+					InsertDateUTC = updatedJob.InsertDateUTC,
+					QueueDateUTC = updatedJob.QueueDateUTC,
+					CompleteDateUTC = updatedJob.CompleteDateUTC,
+					StatusCode = updatedJob.StatusCode,
+					AcknowledgementCode = updatedJob.AcknowledgementCode,
+					AcknowledgementDate = updatedJob.AcknowledgementDate,
+					HasDetailedMessage = updatedJob.HasDetailedMessage,
+					FriendlyDuration = updatedJob.FriendlyDuration,
+				};
+				return;
+			}
+		}
+	}
+
 	private async Task LoadJobsAsync()
 	{
 		(Error? error, GetJobsReply? reply) = await ServiceClient.PostAsync<GetJobsRequest, GetJobsReply>(


### PR DESCRIPTION
## Summary
Closes #30.

### Root cause
When `JobRow.AcknowledgeError` finished, the row called `ReloadJobAsync` and updated **its own** `Job` field to the fresh ACK record returned by `Jobs/GetJob`. But the parent `Jobs` page's `JobDetails` array still held the original ERR `JobWithWorkerID` reference. On the next parent re-render (driven by, among other things, the 15-second clock timer in `NavMenu` re-rendering the layout, or a click on the row-level Filter button from #33), Blazor's parameter binding ran again and reassigned the row's `Job` parameter back to the stale ERR object — making the Acknowledge button reappear and the status flip back to ERR. The user reported "Refreshing fixes it" because Refresh re-fetches and rebuilds `JobDetails` from the server.

### Fix
Add a `ReplaceJob(Job updatedJob)` method on the `Jobs` page that finds the matching entry in `JobDetails` by ID and replaces it with a fresh `JobWithWorkerID` (using the existing `WorkerID` / `WorkerName` and the rest from the updated `Job`, via record `with`-expression). `JobRow.ReloadJobAsync` now calls this after updating its local `Job`, so the parent's array stays in sync and parameter-binding re-renders no longer revert the row.

This also covers the related "RUN" job polling path — the 5-second timer on running jobs also goes through `ReloadJobAsync`, so when a job transitions to SUC/ERR mid-poll, the parent's array now picks that up too.

## Test plan
- [x] `dotnet build` — succeeds with 0 warnings / 0 errors.
- [ ] On the Jobs page, click Acknowledge on an ERR row. Confirm it switches to ACK and stays ACK after ~15 seconds (the NavMenu clock tick that previously triggered the revert).
- [ ] Click the row-level Filter button on a different row right after acknowledging — confirm the previously-acknowledged row is still ACK in the reloaded grid.
- [ ] Start a job that runs long enough to hit the 5-second poll, then let it complete. Confirm the row transitions to SUC and stays SUC.
- [ ] Click Refresh and confirm nothing visually changes for already-correct rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)