### PR TITLE
Removing unsafe logging, updating SQLite package

### DIFF
--- a/SimpleSchedulerAppServices/Implementations/UserManagerBase.cs
+++ b/SimpleSchedulerAppServices/Implementations/UserManagerBase.cs
@@ -78,9 +78,6 @@ public abstract class UserManagerBase : IUserManager
 
     async Task<string> IUserManager.LoginValidateAsync(Guid validationCode, Guid internalSecretAuthKey)
     {
-        _logger.LogDebug("internalSecretAuthKey: {authKey}", internalSecretAuthKey);
-        _logger.LogDebug("validationCode: {validationCode}", validationCode);
-
         if (validationCode == internalSecretAuthKey)
         {
             return "@@internal@@";

--- a/SimpleSchedulerData/SimpleSchedulerData.csproj
+++ b/SimpleSchedulerData/SimpleSchedulerData.csproj
@@ -13,7 +13,8 @@
 		<PackageReference Include="Dapper" Version="2.1.72" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
 		<PackageReference Include="Polly" Version="8.6.6" />
 	</ItemGroup>
 	<ItemGroup>

--- a/SimpleSchedulerFakeData/SimpleSchedulerFakeData.csproj
+++ b/SimpleSchedulerFakeData/SimpleSchedulerFakeData.csproj
@@ -18,7 +18,8 @@
 	<ItemGroup>
 		<PackageReference Include="Bogus" Version="35.6.5" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
 	</ItemGroup>

--- a/SimpleSchedulerServiceClient/ServiceClient.cs
+++ b/SimpleSchedulerServiceClient/ServiceClient.cs
@@ -48,7 +48,6 @@ public class ServiceClient
         }
         try
         {
-            _logger.LogDebug("Token: {token}", token);
             _logger.LogDebug("URL: {baseAddress} | {requestUri}", _httpClient.BaseAddress, requestUri);
             _logger.LogDebug("Request: {request}", request);
 

--- a/SimpleSchedulerTests/SimpleSchedulerTests.csproj
+++ b/SimpleSchedulerTests/SimpleSchedulerTests.csproj
@@ -12,7 +12,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />


### PR DESCRIPTION
 ## Summary

  - Remove `LogDebug` calls in `UserManagerBase.cs` that wrote `internalSecretAuthKey` and `validationCode` to the log in plaintext
  on every email-validation call
  - Remove `LogDebug` call in `ServiceClient.cs` that wrote the Bearer JWT token to the log on every HTTP request

  ## Security impact

  `internalSecretAuthKey` is the master service-account bypass credential — any party with access to debug-level log output (Seq,
  Datadog, a shared log file, a misconfigured forwarder) could extract it and POST it to `/Login/ValidateEmail` to receive a valid
  JWT with no database lookup. `validationCode` exposes the live one-time login token for any user mid-login. The Bearer token leak
  in `ServiceClient` similarly exposes active sessions.

  Closes #71